### PR TITLE
chore: Remove 'trailing-whitespace' and 'end-of-file-fixer' pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,6 @@ repos:
     rev: v3.2.0
     hooks:
     -   id: check-added-large-files
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
 -   repo: local
     hooks:
     - id: nb-clean


### PR DESCRIPTION
# Description

This pull request updates the repository's pre-commit config to remove `trailing-whitespace` and `end-of-file-fixer`.


# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
