### PR TITLE
chore: Disable ruff e501

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,10 @@ extend-select = [
   "RUF",
 ]
 
-ignore = ["E402"]
 
 [tool.ruff.extend-per-file-ignores]
 "*.ipynb" = [
-  "PLE1142" # await-outside-async: Jupyter Notebooks support top level await
+  "PLE1142", # await-outside-async: Jupyter Notebooks support top level await
+  "E402", # module-import-not-at-top-of-file: It's relatively common to have to import "just in time"
+  "E501", # line-too-long: Let black handle this
 ]


### PR DESCRIPTION
# Description

This pull request disables rule `line-too-long` (E501). We'll just let black be our source of truth for formatting


# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.