### PR TITLE
chore: Add `require_serial=true` to nb-clean pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
       name: nb-clean
       description: "Clean Jupyter notebooks of outputs, metadata, and empty cells, with Git integration"
       entry: tox -qqq run -e nb-clean  -- clean
+      require_serial: true
       language: python
       types_or: [jupyter]
       minimum_pre_commit_version: 2.9.2


### PR DESCRIPTION
# Description

Parallelization seemed to be causing intermittent failures on the first run of `pre-commit run nb-clean` in a clean environment (e.g. CI).


# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure/azureml-examples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.