### PR TITLE
QADataGenerator - Fix Chat History Export Format

### DIFF
--- a/notebooks/generate-synthetic-data/ai-generated-data-qna/generate-data-qna.ipynb
+++ b/notebooks/generate-synthetic-data/ai-generated-data-qna/generate-data-qna.ipynb
@@ -369,7 +369,7 @@
    "source": [
     "from typing import List, Union\n",
     "from collections import defaultdict\n",
-    "def export_to_file(output_path: str, qa_type: QAType, results: Union[List, List[List]]):\n",
+    "def export_to_file(output_path: str, qa_type: QAType, results: Union[List, List[List]]) -> None:\n",
     "        \"\"\"\n",
     "            Writes results from QA gen to a jsonl file for Promptflow batch run\n",
     "            results is either a list of questions and answers or list of list of questions and answers grouped by their chunk\n",

--- a/notebooks/generate-synthetic-data/ai-generated-data-qna/generate-data-qna.ipynb
+++ b/notebooks/generate-synthetic-data/ai-generated-data-qna/generate-data-qna.ipynb
@@ -469,7 +469,6 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/generate-synthetic-data/ai-generated-data-qna/generate-data-qna.ipynb
+++ b/notebooks/generate-synthetic-data/ai-generated-data-qna/generate-data-qna.ipynb
@@ -468,7 +468,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/generate-synthetic-data/ai-generated-data-qna/generate-data-qna.ipynb
+++ b/notebooks/generate-synthetic-data/ai-generated-data-qna/generate-data-qna.ipynb
@@ -76,7 +76,7 @@
    "outputs": [],
    "source": [
     "# Install the packages\n",
-    "%pip install azure-identity azure-ai-generative\n",
+    "%pip install azure-identity azure-ai-generative azure-ai-resources\n",
     "%pip install wikipedia langchain nltk unstructured"
    ]
   },
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -317,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,12 +363,57 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import List, Union\n",
+    "from collections import defaultdict\n",
+    "def export_to_file(output_path: str, qa_type: QAType, results: Union[List, List[List]]):\n",
+    "        \"\"\"\n",
+    "            Writes results from QA gen to a jsonl file for Promptflow batch run\n",
+    "            results is either a list of questions and answers or list of list of questions and answers grouped by their chunk\n",
+    "                e.g. [(\"How are you?\", \"I am good.\")]    or [ [(\"How are you?\", \"I am good.\")], [(\"What can I do?\", \"Tell me a joke.\")]\n",
+    "        \"\"\"\n",
+    "        data_dict = defaultdict(list)\n",
+    "        \n",
+    "        if not isinstance(results[0], List):\n",
+    "            results = [results]\n",
+    "        \n",
+    "        for qs_and_as in results:\n",
+    "            chat_history = []\n",
+    "            for question, answer in qs_and_as: \n",
+    "                # always append chat history\n",
+    "                data_dict[\"chat_history\"].append(json.dumps(chat_history))\n",
+    "                if qa_type == QAType.CONVERSATION:\n",
+    "                    data_dict[\"chat_input\"].append(question)\n",
+    "                    chat_history.append({\"role\": \"user\", \"content\": question})\n",
+    "                    chat_history.append({\"role\": \"assistant\", \"content\": answer})\n",
+    "                else:\n",
+    "                    # QnA columns:\n",
+    "                    data_dict[\"question\"].append(question)   \n",
+    "\n",
+    "                data_dict[\"ground_truth\"].append(answer)  # Consider generated answer as the ground truth\n",
+    "\n",
+    "        # export to jsonl file\n",
+    "        try:\n",
+    "            import pandas as pd\n",
+    "        except ImportError as e:\n",
+    "            print(\"In order to write qa data to file, please install pandas\")\n",
+    "            raise e\n",
+    "\n",
+    "        data_df = pd.DataFrame(data_dict, columns=list(data_dict.keys()))\n",
+    "        data_df.to_json(output_path, lines=True, orient=\"records\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
     "output_file = \"generated_qa.jsonl\"\n",
-    "qa_generator.export_to_file(output_file, qa_type, question_answer_list)"
+    "export_to_file(output_file, qa_type, question_answer_list)"
    ]
   },
   {
@@ -423,7 +468,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/generate-synthetic-data/ai-generated-data-qna/generate-data-qna.ipynb
+++ b/notebooks/generate-synthetic-data/ai-generated-data-qna/generate-data-qna.ipynb
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -317,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,7 +408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
# Description
QADataGenerator - Fix export format to comply with chat history schema for evaluations.

# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
