### PR TITLE
Added stricter criteria for video_index_name

### DIFF
--- a/notebooks/GPT-4V/video/video_chatcompletions_example_restapi.ipynb
+++ b/notebooks/GPT-4V/video/video_chatcompletions_example_restapi.ipynb
@@ -94,6 +94,8 @@
     "# Insert your video SAS URL, e.g. https://<your-storage-account-name>.blob.core.windows.net/<your-container-name>/<your-video-name>?<SAS-token>\n",
     "video_SAS_url: str = \"https://gpt4vsamples.blob.core.windows.net/videos/Microsoft%20Copilot%20Short.mp4\"\n",
     "# This index name must be unique\n",
+    "# It must start with alphanumeric, can contain hyphens but they must be followed by alphanumeric (no consecutive hyphens or trailing hyphen).\n",
+    "# It must be 24 characters or less\n",
     "video_index_name: str = \"copilot-video-demo-index\"\n",
     "# This video ID must be unique\n",
     "video_id: str = \"copilot-video-1\"\n",


### PR DESCRIPTION
# Description

<!-- Describe the rationale of your PR. -->
There was an issue where we saw people choosing invalid video index names, the criteria in the notebook were not strict enough so we had to limit character types and lengths that users can provide as specified by the new comment
<!-- Link any issues that it closes. (Closes/Resolves #xxxx.) -->


# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
