### PR TITLE
docs: Ensure all README frontmatters start on the first line

### DIFF
--- a/scenarios/GPT-4V/basic/README.md
+++ b/scenarios/GPT-4V/basic/README.md
@@ -1,4 +1,3 @@
-
 ---
 page_type: sample
 languages:

--- a/scenarios/GPT-4V/enhancement_OCR/README.md
+++ b/scenarios/GPT-4V/enhancement_OCR/README.md
@@ -1,4 +1,3 @@
-
 ---
 page_type: sample
 languages:

--- a/scenarios/GPT-4V/enhancement_grounding/README.md
+++ b/scenarios/GPT-4V/enhancement_grounding/README.md
@@ -1,4 +1,3 @@
-
 ---
 page_type: sample
 languages:

--- a/scenarios/GPT-4V/mutiple_images/README.md
+++ b/scenarios/GPT-4V/mutiple_images/README.md
@@ -1,4 +1,3 @@
-
 ---
 page_type: sample
 languages:

--- a/scenarios/GPT-4V/rag/README.md
+++ b/scenarios/GPT-4V/rag/README.md
@@ -1,4 +1,3 @@
-
 ---
 page_type: sample
 languages:

--- a/scenarios/GPT-4V/video/README.md
+++ b/scenarios/GPT-4V/video/README.md
@@ -1,4 +1,3 @@
-
 ---
 page_type: sample
 languages:

--- a/scenarios/GPT-4V/video_chunk/README.md
+++ b/scenarios/GPT-4V/video_chunk/README.md
@@ -1,4 +1,3 @@
-
 ---
 page_type: sample
 languages:

--- a/scenarios/README-template.md
+++ b/scenarios/README-template.md
@@ -1,4 +1,3 @@
-
 ---
 page_type: sample
 languages:

--- a/scenarios/generate-synthetic-data/ai-generated-data-qna/README.md
+++ b/scenarios/generate-synthetic-data/ai-generated-data-qna/README.md
@@ -1,4 +1,3 @@
-
 ---
 page_type: sample
 languages:

--- a/scenarios/generate-synthetic-data/ai-simulated-interaction-data/README.md
+++ b/scenarios/generate-synthetic-data/ai-simulated-interaction-data/README.md
@@ -1,4 +1,3 @@
-
 ---
 page_type: sample
 languages:

--- a/scenarios/rag/rag-e2e/README.md
+++ b/scenarios/rag/rag-e2e/README.md
@@ -1,4 +1,3 @@
-
 ---
 page_type: sample
 languages:

--- a/scenarios/rag/rag-index-creation/README.md
+++ b/scenarios/rag/rag-index-creation/README.md
@@ -1,4 +1,3 @@
-
 ---
 page_type: sample
 languages:


### PR DESCRIPTION
# Description

This pull request is a follow up to #51 that ensures that frontmatters start on the first line of the markdown file (They seem to otherwise be parsed as markdown).


# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
