### PR TITLE
fixed a MD ref to the assistant api bot in a box architecture (img link)

### DIFF
--- a/scenarios/Assistants/assistant-bot-in-a-box/README.md
+++ b/scenarios/Assistants/assistant-bot-in-a-box/README.md
@@ -7,7 +7,7 @@ This project deploys a virtual Assistant template to Azure.
 
 The solution architecture is described in the diagram below.
 
-![Solution Architecture](./readme_assets/architecture.png)
+![Solution Architecture](readme_assets/architecture.png)
 
 The flow of messages is as follows:
 

--- a/scenarios/Assistants/assistant-bot-in-a-box/README.md
+++ b/scenarios/Assistants/assistant-bot-in-a-box/README.md
@@ -7,7 +7,7 @@ This project deploys a virtual Assistant template to Azure.
 
 The solution architecture is described in the diagram below.
 
-![Solution Architecture](./readme_assets/architecture-to-be-added.png)
+![Solution Architecture](./readme_assets/architecture.png)
 
 The flow of messages is as follows:
 


### PR DESCRIPTION
# Description

<!-- Describe the rationale of your PR. -->
The image ref to the sol arch was broken, even though that the img exists in the readme_assets folder. 
![image](https://github.com/Azure-Samples/azureai-samples/assets/13098307/32c345a4-b818-4d4f-8f53-6ba2b5faac90)
(the PR fixes that )
<!-- Link any issues that it closes. (Closes/Resolves #xxxx.) -->


# Checklist


- [X] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [X] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions. *-> NO file structure changes*
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
