### PR TITLE
docs: Fix links broken from `notebooks/` -> `scenarios/` rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,6 @@ Edit the product, description, and languages as needed.
 
 The Code Samples browser content is updated twice a week, so it may take a few days for your changes to be reflected.
 
-[readme template]: ./notebooks/README-template.md
-[jupyter notebook template]: ./notebooks/template.ipynb
+[readme template]: ./scenarios/README-template.md
+[jupyter notebook template]: ./scenarios/template.ipynb
 

--- a/scenarios/rag/rag-e2e/rag-qna.ipynb
+++ b/scenarios/rag/rag-e2e/rag-qna.ipynb
@@ -52,7 +52,7 @@
    "source": [
     "### Data\n",
     "\n",
-    "This sample uses files from the folder `notebooks/rag/rag-e2e/data/product-info` in this repo. You can clone this repo or copy this folder to make sure you have access to these files when running the sample."
+    "This sample uses files from the folder [`data/product-info/`](./data/product-info) in this repo. You can clone this repo or copy this folder to make sure you have access to these files when running the sample."
    ]
   },
   {


### PR DESCRIPTION
# Description




# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
