### PR TITLE
docs: Add a callout about budgeting in time for PR review

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,15 @@ Note that samples are organized by scenario, find the one best-suited for your s
 
 That's it! Thank you for your contribution!
 
+> [!IMPORTANT]
+>
+> You should expect to budget time to engage with reviewers (responding to comments, fixing PR checks) before your PR is merged in. This is especially
+> relevant if your contribution is _time-sensitive_.
+>
+> Adhering to the guidance in this document (i.e [using pre-commit](#3-set-up-pre-commit), [using provided templates](#write-your-contribution)) ***will***
+> help expedite the review process.
+
+
 ### Discoverability
 
 Examples in this repository can be indexed in the [Microsoft code samples browser](https://docs.microsoft.com/samples), enabling organic discoverability. To accomplish this, add the required YAML frontmatter at the top of the `README.md`


### PR DESCRIPTION
# Description

This pull request adds a callout to CONTRIBUTING.md to ensure that new contributors are aware that they should expect to allocate time to participate in the review of their PRs.


# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
