### PR TITLE
Fixed python comparison operator in reference sample code

### DIFF
--- a/scenarios/Assistants/api-in-a-box/README.md
+++ b/scenarios/Assistants/api-in-a-box/README.md
@@ -126,10 +126,10 @@ while True:
         client.beta.threads.delete(thread.id)
         
         break
-    elif run.status = "requires_action":
+    elif run.status == "requires_action":
         # handle funcation calling and continue with the execution
         pass
-    elif run.status = "expired" or run.status=="failed" or run.status=="cancelled":
+    elif run.status == "expired" or run.status == "failed" or run.status == "cancelled":
         # run failed, expired, or was cancelled
         break    
     else:


### PR DESCRIPTION
# Description

This pull request fixes two python comparison operators in the reference sample code.


# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
