### PR TITLE
chore: Bump ruff to 0.3.4

### DIFF
--- a/.github/scripts/commit-filesize-diff-summary.py
+++ b/.github/scripts/commit-filesize-diff-summary.py
@@ -166,7 +166,7 @@ def num_bytes(arg: str) -> int:
         "YB": 8,
     }
 
-    shift = shift_values.get(suffix, None)
+    shift = shift_values.get(suffix)
 
     if shift is None:
         raise error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ line-length = 120
 
 [tool.ruff]
 line-length = 120
+
+[tool.ruff.lint]
 extend-select = [
   "B",
   "C4",
@@ -18,7 +20,7 @@ extend-select = [
 ]
 
 
-[tool.ruff.extend-per-file-ignores]
+[tool.ruff.lint.extend-per-file-ignores]
 "*.ipynb" = [
   "PLE1142", # await-outside-async: Jupyter Notebooks support top level await
   "E402", # module-import-not-at-top-of-file: It's relatively common to have to import "just in time"

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands = black {posargs}
 
 [testenv:ruff]
 deps =
-    ruff ~= 0.0.292
+    ruff ~= 0.3.4
 commands = ruff {posargs}
 
 [testenv:nb-clean]


### PR DESCRIPTION
# Description

This pull request bumps the version of ruff used in our tox config to 0.3.4


# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
