### PR TITLE
Fix issues with evaluate at endpoint

### DIFF
--- a/scenarios/evaluate-an-endpoint/askwiki.py
+++ b/scenarios/evaluate-an-endpoint/askwiki.py
@@ -23,7 +23,9 @@ session = requests.Session()
 # Set up Jinja2 for templating
 templateLoader = jinja2.FileSystemLoader(pathlib.Path(__file__).parent.parent.resolve())
 templateEnv = jinja2.Environment(loader=templateLoader)
-system_message_template = templateEnv.get_template("generate-synthetic-data/simulate-adversarial-interactions/askwiki/system-message.jinja2")
+system_message_template = templateEnv.get_template(
+    "generate-synthetic-data/simulate-adversarial-interactions/askwiki/system-message.jinja2"
+)
 
 
 # Function to decode a string
@@ -183,6 +185,7 @@ def augemented_qa(question: str, context: str) -> str:
 class Response(TypedDict):
     answer: str
     context: str
+
 
 def ask_wiki(question: str) -> Response:
     url_list = get_wiki_url(question, count=2)

--- a/scenarios/evaluate-an-endpoint/askwiki.py
+++ b/scenarios/evaluate-an-endpoint/askwiki.py
@@ -14,16 +14,16 @@ import bs4
 import re
 from concurrent.futures import ThreadPoolExecutor
 from openai import AzureOpenAI
-from typing import List, Tuple, Dict
+from typing import List, Tuple, TypedDict
 
 
 # Create a session for making HTTP requests
 session = requests.Session()
 
 # Set up Jinja2 for templating
-templateLoader = jinja2.FileSystemLoader(pathlib.Path(__file__).parent.resolve())
+templateLoader = jinja2.FileSystemLoader(pathlib.Path(__file__).parent.parent.resolve())
 templateEnv = jinja2.Environment(loader=templateLoader)
-system_message_template = templateEnv.get_template("system-message.jinja2")
+system_message_template = templateEnv.get_template("generate-synthetic-data/simulate-adversarial-interactions/askwiki/system-message.jinja2")
 
 
 # Function to decode a string
@@ -178,7 +178,13 @@ def augemented_qa(question: str, context: str) -> str:
 
 
 # Function to ask Wikipedia
-def ask_wiki(question: str) -> Dict[str, str]:
+
+
+class Response(TypedDict):
+    answer: str
+    context: str
+
+def ask_wiki(question: str) -> Response:
     url_list = get_wiki_url(question, count=2)
     search_result = search_result_from_url(url_list, count=10)
     context = process_search_result(search_result)

--- a/scenarios/evaluate-an-endpoint/askwiki.py
+++ b/scenarios/evaluate-an-endpoint/askwiki.py
@@ -23,9 +23,7 @@ session = requests.Session()
 # Set up Jinja2 for templating
 templateLoader = jinja2.FileSystemLoader(pathlib.Path(__file__).parent.resolve())
 templateEnv = jinja2.Environment(loader=templateLoader)
-system_message_template = templateEnv.get_template(
-    "system-message.jinja2"
-)
+system_message_template = templateEnv.get_template("system-message.jinja2")
 
 
 # Function to decode a string

--- a/scenarios/evaluate-an-endpoint/askwiki.py
+++ b/scenarios/evaluate-an-endpoint/askwiki.py
@@ -21,10 +21,10 @@ from typing import List, Tuple, TypedDict
 session = requests.Session()
 
 # Set up Jinja2 for templating
-templateLoader = jinja2.FileSystemLoader(pathlib.Path(__file__).parent.parent.resolve())
+templateLoader = jinja2.FileSystemLoader(pathlib.Path(__file__).parent.resolve())
 templateEnv = jinja2.Environment(loader=templateLoader)
 system_message_template = templateEnv.get_template(
-    "generate-synthetic-data/simulate-adversarial-interactions/askwiki/system-message.jinja2"
+    "system-message.jinja2"
 )
 
 

--- a/scenarios/evaluate-an-endpoint/system-message.jinja2
+++ b/scenarios/evaluate-an-endpoint/system-message.jinja2
@@ -1,0 +1,5 @@
+You are a chatbot having a conversation with a human.
+Given the following extracted parts of a long document and a question, create a final answer.
+If you don't know the answer, just say that you don't know. Don't try to make up an answer.
+
+{{contexts}}


### PR DESCRIPTION
# Description
I ran into the following issues running the `Evaluate at Endpoint` notebook
1. Jinja template path was not being picked up
2. Running evaluate was giving
```
GenerateFlowMetaJsonError: Generate meta failed, detail error:
["Parse interface for 'ask_wiki' failed: The return annotation of the entry function must be dataclass, TypedDict or string, but got typing.Dict[str, str]."]
```
<!-- Describe the rationale of your PR. -->
<!-- Link any issues that it closes. (Closes/Resolves #xxxx.) -->


# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
