### PR TITLE
Improved quality of custom evaluators notebook

### DIFF
--- a/scenarios/evaluate/Supported_Evaluation_Metrics/Custom_Evaluators/Custom_Evaluators.ipynb
+++ b/scenarios/evaluate/Supported_Evaluation_Metrics/Custom_Evaluators/Custom_Evaluators.ipynb
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "257fd898-7ef2-4d89-872e-da9e426aaf0b",
    "metadata": {},
    "outputs": [],
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "fbfc3a3b",
    "metadata": {},
    "outputs": [],
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "cd9bb466-324f-42ce-924a-56e1bc52471e",
    "metadata": {},
    "outputs": [],
@@ -175,7 +175,7 @@
    "source": [
     "from blocklist import BlocklistEvaluator\n",
     "\n",
-    "blocklist_evaluator = BlocklistEvaluator(blocklist=[\"bad, worst, terrible\"])\n",
+    "blocklist_evaluator = BlocklistEvaluator(blocklist=[\"bad\", \"worst\", \"terrible\"])\n",
     "\n",
     "blocklist_evaluator(response=\"New Delhi is Capital of India\")"
    ]
@@ -231,11 +231,19 @@
    "source": [
     "pd.DataFrame(results[\"rows\"])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef355fa6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv-azureai-samples",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -248,7 +256,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/scenarios/evaluate/Supported_Evaluation_Metrics/Custom_Evaluators/Custom_Evaluators.ipynb
+++ b/scenarios/evaluate/Supported_Evaluation_Metrics/Custom_Evaluators/Custom_Evaluators.ipynb
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "257fd898-7ef2-4d89-872e-da9e426aaf0b",
    "metadata": {},
    "outputs": [],
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "fbfc3a3b",
    "metadata": {},
    "outputs": [],
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "cd9bb466-324f-42ce-924a-56e1bc52471e",
    "metadata": {},
    "outputs": [],
@@ -256,8 +256,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/scenarios/evaluate/Supported_Evaluation_Metrics/Custom_Evaluators/blocklist.py
+++ b/scenarios/evaluate/Supported_Evaluation_Metrics/Custom_Evaluators/blocklist.py
@@ -8,5 +8,5 @@ class BlocklistEvaluator:
         self._blocklist = blocklist
 
     def __call__(self: "BlocklistEvaluator", *, response: str):  # noqa: ANN204
-        score = any(word in response for word in self._blocklist)
+        score = any(word in self._blocklist for word in response.split())
         return {"score": score}


### PR DESCRIPTION
- `BlocklistEvaluator` wasn't detecting words in `blocklist`.
- `blocklist` init parameter for `BlocklistEvaluator` was fixed to be an array of words.

# Description

<!-- Describe the rationale of your PR. -->
<!-- Link any issues that it closes. (Closes/Resolves #xxxx.) -->


# Checklist


- [x] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
