### PR TITLE
fix: Add skip autodelete tag when creating resource gruop

### DIFF
--- a/.infra/deployment/main.bicep
+++ b/.infra/deployment/main.bicep
@@ -2,6 +2,14 @@ targetScope = 'subscription'
 param workspaceName string = 'azureai_samples_hub'
 param projectName string = 'azureai_samples_proj'
 param resourceGroupName string = 'rg-azureai-samples-validation-${utcNow('yyyyMM')}'
+
+@description('The first day of the next month at deployment time in yyyy-MM-DD format.')
+param __firstOfNextMonth string = '${dateTimeAdd('${utcNow('yyyy-MM')}-01 00:00:00Z', 'P31D', 'yyyy-MM')}-01'
+
+param resourceGroupTags object = {
+  SkipAutoDeleteTill: __firstOfNextMonth
+}
+
 param location string = 'eastus2'
 @description('The ID of the principal (user, service principal, etc...) to create role assignments for.')
 param principalId string = ''
@@ -16,6 +24,7 @@ resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
   #disable-next-line use-stable-resource-identifiers
   name: resourceGroupName
   location: location
+  tags: resourceGroupTags
 }
 
 module acs 'modules/acs.bicep' = { name: 'acs', params: { name: acsName, location: location }, scope: rg }


### PR DESCRIPTION
# Description

This pull request updates the infra bicep file so that it defaults to applying a "SkipAutoDeleteTill" tag to the resource group

# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
