### PR TITLE
ci,fix: Resolve crash when running samples in PR from fork

### DIFF
--- a/.github/workflows/run-samples.yml
+++ b/.github/workflows/run-samples.yml
@@ -83,4 +83,4 @@ jobs:
               -o json > deployment.json
       - name: Run samples
         run:
-            pytest --changed-samples-only-from ${{ github.base_ref }}
+            pytest --changed-samples-only-from ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/run-samples.yml
+++ b/.github/workflows/run-samples.yml
@@ -82,6 +82,6 @@ jobs:
               --parameters principalType=ServicePrincipal \
               --parameters principalId="$principalId" \
               -o json > deployment.json
-      - name: Run samples
+      - name: Run Changed Samples
         run:
             pytest --changed-samples-only-from ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/run-samples.yml
+++ b/.github/workflows/run-samples.yml
@@ -60,6 +60,7 @@ jobs:
     environment: ${{ needs.check-if-external.outputs.environment }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - uses: actions/setup-python@v5

--- a/.infra/pytest_plugins/changed_samples/src/pytest_changed_samples/plugin.py
+++ b/.infra/pytest_plugins/changed_samples/src/pytest_changed_samples/plugin.py
@@ -84,8 +84,8 @@ def get_diff_paths_function(config: pytest.Config) -> Callable[[], Iterable[Path
     """
     if config.getoption(opt_var(WORKING_TREE_CHANGES_OPTION)):
         return get_all_modified_paths
-    if config.getoption(opt_var(PR_CHANGES_OPTION)):
-        return get_branch_diff_paths
+    if ref := config.getoption(opt_var(PR_CHANGES_OPTION)):
+        return lambda: get_branch_diff_paths(ref)
 
     return lambda: ()
 


### PR DESCRIPTION
# Description

This pull request resolves an issue where `git diff` (which is used to compute changed samples) fails from PRs that come from forks.

Specifically:

* Fixes an issue with the custom `changed samples` plugin where it wasn't using the git ref specified at the command line
* Added an extra `actions/checkout` step, which checks out the base commit that we diff against.

# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
