### PR TITLE
Setting data parameter type String in evaluate()

### DIFF
--- a/scenarios/rag/custom-rag-app/evaluate.py
+++ b/scenarios/rag/custom-rag-app/evaluate.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
 
     # run evaluation with a dataset and target function, log to the project
     result = evaluate(
-        data=Path(ASSET_PATH) / "chat_eval_data.jsonl",
+        data=str(Path(ASSET_PATH) / "chat_eval_data.jsonl"),
         target=evaluate_chat_with_products,
         evaluation_name="evaluate_chat_with_products",
         evaluators={


### PR DESCRIPTION

This pull request includes a minor change to the `evaluate_chat_with_products` function in the `evaluate.py` file. The change involves converting the data path to a string format to fix `raise EvaluationException( azure.ai.evaluation._exceptions.EvaluationException: data parameter must be a string.` error.

* [`scenarios/rag/custom-rag-app/evaluate.py`](diffhunk://#diff-0215fd57701aca13b58b7f9f4731e9eee6339e4d86bfae817dbdb6ab74a60cadL61-R61): Modified the `data` parameter in the `evaluate` function call to use `str(Path(ASSET_PATH) / "chat_eval_data.jsonl")` instead of `Path(ASSET_PATH) / "chat_eval_data.jsonl"`.
