### PR TITLE
Update/Fix Relevance-Evaluator id

### DIFF
--- a/scenarios/evaluate/Supported_Evaluation_Targets/Evaluate_On_Cloud/Evaluate_On_Cloud.ipynb
+++ b/scenarios/evaluate/Supported_Evaluation_Targets/Evaluate_On_Cloud/Evaluate_On_Cloud.ipynb
@@ -180,12 +180,12 @@
     "    \"relevance\": EvaluatorConfiguration(\n",
     "        id=\"azureml://registries/azureml/models/Relevance-Evaluator/versions/5\",\n",
     "        init_params={\"model_config\": model_config},\n",
-    "        data_mapping={\"query\": \"${data.Input}\", \"response\": \"${data.Output}\"},\n",
+    "        data_mapping={\"query\": \"${data.query}\", \"response\": \"${data.response}\"},\n",
     "    ),\n",
     "    \"violence\": EvaluatorConfiguration(\n",
     "        id=ViolenceEvaluator.id,\n",
     "        init_params={\"azure_ai_project\": project_client.scope},\n",
-    "        data_mapping={\"query\": \"${data.Input}\", \"response\": \"${data.Output}\"},\n",
+    "        data_mapping={\"query\": \"${data.query}\", \"response\": \"${data.response}\"},\n",
     "    ),\n",
     "}"
    ]

--- a/scenarios/evaluate/Supported_Evaluation_Targets/Evaluate_On_Cloud/Evaluate_On_Cloud.ipynb
+++ b/scenarios/evaluate/Supported_Evaluation_Targets/Evaluate_On_Cloud/Evaluate_On_Cloud.ipynb
@@ -178,7 +178,7 @@
     "        id=F1ScoreEvaluator.id,\n",
     "    ),\n",
     "    \"relevance\": EvaluatorConfiguration(\n",
-    "        id=\"azureml://registries/azureml-staging/models/Relevance-Evaluator/versions/4\",\n",
+    "        id=\"azureml://registries/azureml/models/Relevance-Evaluator/versions/5\",\n",
     "        init_params={\"model_config\": model_config},\n",
     "        data_mapping={\"query\": \"${data.Input}\", \"response\": \"${data.Output}\"},\n",
     "    ),\n",

--- a/scenarios/evaluate/Supported_Evaluation_Targets/Evaluate_Online/Evaluate_Online.ipynb
+++ b/scenarios/evaluate/Supported_Evaluation_Targets/Evaluate_Online/Evaluate_Online.ipynb
@@ -169,7 +169,7 @@
     "        id=F1ScoreEvaluator.id,\n",
     "    ),\n",
     "    \"relevance\": EvaluatorConfiguration(\n",
-    "        id=\"azureml://registries/azureml-staging/models/Relevance-Evaluator/versions/4\",\n",
+    "        id=\"azureml://registries/azureml/models/Relevance-Evaluator/versions/5\",\n",
     "        init_params={\"model_config\": model_config},\n",
     "        data_mapping={\"query\": \"${data.Input}\", \"response\": \"${data.Output}\"},\n",
     "    ),\n",


### PR DESCRIPTION
# Description

The id used for the Relevance-Evaluator was wrong. Using that resulted in an error when running evaluations.

The error was about missing permissions for the azureml-staging container registry.

# Checklist


- [x ] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [x ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
