### PR TITLE
ci,fix: Pin version of bicep-cli used by pre-commit

### DIFF
--- a/.github/scripts/build_agent_setup_bicep.py
+++ b/.github/scripts/build_agent_setup_bicep.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 from azure.cli.core import get_default_cli
@@ -26,6 +27,10 @@ def build_bicep_file(bicep_file: Path) -> None:
     output_file = bicep_file.with_name("azuredeploy.json")
 
     print(f"🔹 Building Bicep: {bicep_file} -> {output_file}")
+    os.environ.update({"AZURE_BICEP_USE_BINARY_FROM_PATH": "false", "AZURE_BICEP_CHECK_VERSION": "false"})
+
+    # Pin the bicep CLI to minimize pre-commit failures due to modified metadata in files.
+    run_az_command("bicep", "install", "--version", "v0.33.93")
 
     # Run az bicep build using Azure CLI SDK
     run_az_command("bicep", "build", "--file", str(bicep_file), "--outfile", str(output_file))

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,11 +43,10 @@ repos:
     - id: bicep-build
       name: Regenerate azuredeploy.json for Agent samples
       description: "Automatically build Bicep files into azuredeploy.json before commit"
-      entry: python .github/scripts/build_agent_setup_bicep.py
       types: [text]
       files: ^scenarios/Agents/setup/.*\.bicep$
-      language: python
       require_serial: true
       pass_filenames: true
-      additional_dependencies:
-      - azure-cli
+      entry: python
+      language: system
+      args: ["-m", "tox", "-qqq", "run", "-e", "build-agent-bicep", "--"]

--- a/tox.ini
+++ b/tox.ini
@@ -28,3 +28,11 @@ commands = typos {posargs}
 deps =
     -r dev-requirements.txt
 commands = pytest {posargs}
+
+
+[testenv:build-agent-bicep]
+deps =
+    azure-cli
+set_env =
+    AZURE_CONFIG_DIR={env_tmp_dir}/azure
+commands = python .github/scripts/build_agent_setup_bicep.py {posargs}


### PR DESCRIPTION

# Description

    Bicep includes its version and a hash of the template as metadata
    in the file produced when running `bicep build`. Different versions
    of bicep-cli produce differing values for those fields, which
    can break `pre-commit run --all` when run against changes that
    don't touch any bicep files.

    Pinning bicep-cli should keep those fields consistent until
    bicep is intentionally upgraded.



# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
