### PR TITLE
chore: Remove ignore for ANN101 in ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,6 @@ extend-select = [
   "ANN",
   "RUF",
 ]
-ignore = [
-  "ANN101", # missing-type-self: This can be inferred and will be deprecated by ruff
-]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "*.ipynb" = [


### PR DESCRIPTION
# Description

The rule was removed in [ruff 0.8.0](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#080)



# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
