### PR TITLE
test,fix: Force pytest to exit zero when no tests are collected

### DIFF
--- a/.infra/pytest_plugins/changed_samples/src/pytest_changed_samples/plugin.py
+++ b/.infra/pytest_plugins/changed_samples/src/pytest_changed_samples/plugin.py
@@ -13,6 +13,11 @@ WORKING_TREE_CHANGES_OPTION = "--changed-samples-only"
 PR_CHANGES_OPTION = "--changed-samples-only-from"
 
 
+def is_plugin_active(config: pytest.Config) -> bool:
+    """Return whether any of the plugin provided options were provided on commandline."""
+    return get_diff_paths_function(config) is not None
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption(
         WORKING_TREE_CHANGES_OPTION,
@@ -45,7 +50,14 @@ def pytest_collection(session: pytest.Session) -> None:
     config = session.config
     diff_path_trie = Trie()
 
-    for p in get_diff_paths_function(config)():
+    paths_filter = get_diff_paths_function(config)
+
+    if paths_filter is None:
+        # Exit early if there's no path filter
+        yield
+        return
+
+    for p in paths_filter():
         diff_path_trie.insert(p.parts)
 
     config.stash[DIFF_PATH_TRIE_KEY] = diff_path_trie
@@ -72,7 +84,16 @@ def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> Optio
     return (not diff_path_trie.is_prefix(ignore_dir.resolve().parts)) or None
 
 
-def get_diff_paths_function(config: pytest.Config) -> Callable[[], Iterable[Path]]:
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    if not is_plugin_active(session.config):
+        return
+
+    if exitstatus == pytest.ExitCode.NO_TESTS_COLLECTED:
+        session.exitstatus = pytest.ExitCode.OK
+
+
+def get_diff_paths_function(config: pytest.Config) -> Optional[Callable[[], Iterable[Path]]]:
     """Get the function that returns paths present in a diff specfied by cmdline arguments
 
     :param pytest.Config config: The pytest config
@@ -87,7 +108,7 @@ def get_diff_paths_function(config: pytest.Config) -> Callable[[], Iterable[Path
     if ref := config.getoption(opt_var(PR_CHANGES_OPTION)):
         return lambda: get_branch_diff_paths(ref)
 
-    return lambda: ()
+    return None
 
 
 def opt_var(s: str) -> str:

--- a/.infra/pytest_plugins/changed_samples/src/pytest_changed_samples/plugin.py
+++ b/.infra/pytest_plugins/changed_samples/src/pytest_changed_samples/plugin.py
@@ -47,6 +47,7 @@ def pytest_configure(config: pytest.Config) -> None:
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_collection(session: pytest.Session) -> None:
+    """Set up path filtering based on git diff."""
     config = session.config
     diff_path_trie = Trie()
 
@@ -68,8 +69,9 @@ def pytest_collection(session: pytest.Session) -> None:
 
 
 def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> Optional[bool]:
+    """Ignore paths that were not touched by the current git diff."""
     if DIFF_PATH_TRIE_KEY not in config.stash:
-        # Occures when calling `pytest --fixtures`
+        # Occurs when calling `pytest --fixtures`
         return None
 
     diff_path_trie = config.stash[DIFF_PATH_TRIE_KEY]


### PR DESCRIPTION
# Description

Pytest considers it an error when pytest is invoked and no tests are collected (pytest-dev/pytest#2393). In the context of our local plugin that filters tests based on the git diff, this behavior is undesirable since it causes CI to fail when a PR doesn't touch a sample.

This PR updates our local plugin to force pytest to exit 0 when no tests are collected and any of the plugin's commandline arguments were provided.


# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
