### PR TITLE
chore: Add docs team as owner for docs folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,5 @@
 
 # Default owner for everything, unless overridden by a more specific rule.
 * @Azure-Samples/azure-ai-samples-maintainers
+
+scenarios/docs @Azure-Samples/azure-ai-samples-maintainers @Azure-Samples/AI-Platform-Docs


### PR DESCRIPTION
# Description


# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
