### PR TITLE
Support new container role assignment for agent thread-storage bicep

### DIFF
--- a/scenarios/Agents/setup/network-secured-agent-thread-storage/azuredeploy.json
+++ b/scenarios/Agents/setup/network-secured-agent-thread-storage/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "9155466085938045893"
+      "templateHash": "9204291102583499292"
     }
   },
   "parameters": {
@@ -2562,7 +2562,7 @@
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-deployment', toLower(format('{0}', parameters('defaultAiProjectName'))), parameters('uniqueSuffix'))]",
+      "name": "[format('cosmos-ra-{0}-{1}-deployment', toLower(format('{0}', parameters('defaultAiProjectName'))), parameters('uniqueSuffix'))]",
       "subscriptionId": "[variables('cosmosDBSubscriptionId')]",
       "resourceGroup": "[variables('cosmosDBResourceGroupName')]",
       "properties": {

--- a/scenarios/Agents/setup/network-secured-agent-thread-storage/azuredeploy.json
+++ b/scenarios/Agents/setup/network-secured-agent-thread-storage/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "12425839983447429475"
+      "templateHash": "9155466085938045893"
     }
   },
   "parameters": {
@@ -2562,7 +2562,7 @@
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('cosmos-container-role-assignments-{0}-{1}-deployment', toLower(format('{0}', parameters('defaultAiProjectName'))), parameters('uniqueSuffix'))]",
+      "name": "[format('{0}-{1}-deployment', toLower(format('{0}', parameters('defaultAiProjectName'))), parameters('uniqueSuffix'))]",
       "subscriptionId": "[variables('cosmosDBSubscriptionId')]",
       "resourceGroup": "[variables('cosmosDBResourceGroupName')]",
       "properties": {
@@ -2591,7 +2591,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "3236725067655686559"
+              "templateHash": "2433285251744228821"
             }
           },
           "parameters": {
@@ -2620,9 +2620,11 @@
           "variables": {
             "userThreadName": "[format('{0}-thread-message-store', parameters('projectWorkspaceId'))]",
             "systemThreadName": "[format('{0}-system-thread-message-store', parameters('projectWorkspaceId'))]",
+            "agentEntityStoreName": "[format('{0}-agent-entity-store', parameters('projectWorkspaceId'))]",
             "roleDefinitionId": "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', parameters('cosmosAccountName'), '00000000-0000-0000-0000-000000000002')]",
             "scopeSystemContainer": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DocumentDB/databaseAccounts/{2}/dbs/enterprise_memory/colls/{3}', subscription().subscriptionId, resourceGroup().name, parameters('cosmosAccountName'), variables('systemThreadName'))]",
-            "scopeUserContainer": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DocumentDB/databaseAccounts/{2}/dbs/enterprise_memory/colls/{3}', subscription().subscriptionId, resourceGroup().name, parameters('cosmosAccountName'), variables('userThreadName'))]"
+            "scopeUserContainer": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DocumentDB/databaseAccounts/{2}/dbs/enterprise_memory/colls/{3}', subscription().subscriptionId, resourceGroup().name, parameters('cosmosAccountName'), variables('userThreadName'))]",
+            "scopeAgentEntityContainer": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DocumentDB/databaseAccounts/{2}/dbs/enterprise_memory/colls/{3}', subscription().subscriptionId, resourceGroup().name, parameters('cosmosAccountName'), variables('agentEntityStoreName'))]"
           },
           "resources": [
             {
@@ -2643,6 +2645,16 @@
                 "principalId": "[parameters('aiProjectPrincipalId')]",
                 "roleDefinitionId": "[variables('roleDefinitionId')]",
                 "scope": "[variables('scopeSystemContainer')]"
+              }
+            },
+            {
+              "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
+              "apiVersion": "2022-05-15",
+              "name": "[format('{0}/{1}', parameters('cosmosAccountName'), guid(parameters('aiProjectId'), resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers', parameters('cosmosAccountName'), 'enterprise_memory', variables('agentEntityStoreName')), variables('roleDefinitionId')))]",
+              "properties": {
+                "principalId": "[parameters('aiProjectPrincipalId')]",
+                "roleDefinitionId": "[variables('roleDefinitionId')]",
+                "scope": "[variables('scopeAgentEntityContainer')]"
               }
             }
           ]

--- a/scenarios/Agents/setup/network-secured-agent-thread-storage/main.bicep
+++ b/scenarios/Agents/setup/network-secured-agent-thread-storage/main.bicep
@@ -375,7 +375,7 @@ module addCapabilityHost 'modules-network-secured/network-capability-host.bicep'
 }
 
 module cosmosContainerRoleAssignments 'modules-network-secured/database/cosmos-container-role-assignment.bicep' = {
-  name: '${toLower('${defaultAiProjectName}')}-${uniqueSuffix}-deployment'
+  name: 'cosmos-ra-${toLower('${defaultAiProjectName}')}-${uniqueSuffix}-deployment'
   scope: resourceGroup(cosmosDBSubscriptionId, cosmosDBResourceGroupName)
   params: {
     cosmosAccountName: aiDependencies.outputs.cosmosDBName

--- a/scenarios/Agents/setup/network-secured-agent-thread-storage/main.bicep
+++ b/scenarios/Agents/setup/network-secured-agent-thread-storage/main.bicep
@@ -375,7 +375,7 @@ module addCapabilityHost 'modules-network-secured/network-capability-host.bicep'
 }
 
 module cosmosContainerRoleAssignments 'modules-network-secured/database/cosmos-container-role-assignment.bicep' = {
-  name: 'cosmos-container-role-assignments-${toLower('${defaultAiProjectName}')}-${uniqueSuffix}-deployment'
+  name: '${toLower('${defaultAiProjectName}')}-${uniqueSuffix}-deployment'
   scope: resourceGroup(cosmosDBSubscriptionId, cosmosDBResourceGroupName)
   params: {
     cosmosAccountName: aiDependencies.outputs.cosmosDBName

--- a/scenarios/Agents/setup/standard-agent-with-threadstorage/azuredeploy.json
+++ b/scenarios/Agents/setup/standard-agent-with-threadstorage/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "17154956640074748586"
+      "templateHash": "3586167999213672571"
     }
   },
   "parameters": {
@@ -1594,7 +1594,7 @@
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('cosmos-container-role-assignments-{0}-{1}-deployment', variables('projectName'), variables('uniqueSuffix'))]",
+      "name": "[format('{0}-{1}-deployment', toLower(format('{0}', variables('projectName'))), variables('uniqueSuffix'))]",
       "subscriptionId": "[variables('cosmosDBSubscriptionId')]",
       "resourceGroup": "[variables('cosmosDBResourceGroupName')]",
       "properties": {
@@ -1623,7 +1623,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "4005997312279995865"
+              "templateHash": "580164018367721578"
             }
           },
           "parameters": {
@@ -1652,9 +1652,11 @@
           "variables": {
             "userThreadName": "[format('{0}-thread-message-store', parameters('projectWorkspaceId'))]",
             "systemThreadName": "[format('{0}-system-thread-message-store', parameters('projectWorkspaceId'))]",
+            "agentEntityStoreName": "[format('{0}-agent-entity-store', parameters('projectWorkspaceId'))]",
             "roleDefinitionId": "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', parameters('cosmosAccountName'), '00000000-0000-0000-0000-000000000002')]",
             "scopeSystemContainer": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DocumentDB/databaseAccounts/{2}/dbs/enterprise_memory/colls/{3}', subscription().subscriptionId, resourceGroup().name, parameters('cosmosAccountName'), variables('systemThreadName'))]",
-            "scopeUserContainer": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DocumentDB/databaseAccounts/{2}/dbs/enterprise_memory/colls/{3}', subscription().subscriptionId, resourceGroup().name, parameters('cosmosAccountName'), variables('userThreadName'))]"
+            "scopeUserContainer": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DocumentDB/databaseAccounts/{2}/dbs/enterprise_memory/colls/{3}', subscription().subscriptionId, resourceGroup().name, parameters('cosmosAccountName'), variables('userThreadName'))]",
+            "scopeAgentEntityContainer": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DocumentDB/databaseAccounts/{2}/dbs/enterprise_memory/colls/{3}', subscription().subscriptionId, resourceGroup().name, parameters('cosmosAccountName'), variables('agentEntityStoreName'))]"
           },
           "resources": [
             {
@@ -1675,6 +1677,16 @@
                 "principalId": "[parameters('aiProjectPrincipalId')]",
                 "roleDefinitionId": "[variables('roleDefinitionId')]",
                 "scope": "[variables('scopeSystemContainer')]"
+              }
+            },
+            {
+              "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
+              "apiVersion": "2022-05-15",
+              "name": "[format('{0}/{1}', parameters('cosmosAccountName'), guid(parameters('aiProjectId'), resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers', parameters('cosmosAccountName'), 'enterprise_memory', variables('agentEntityStoreName')), variables('roleDefinitionId')))]",
+              "properties": {
+                "principalId": "[parameters('aiProjectPrincipalId')]",
+                "roleDefinitionId": "[variables('roleDefinitionId')]",
+                "scope": "[variables('scopeAgentEntityContainer')]"
               }
             }
           ]

--- a/scenarios/Agents/setup/standard-agent-with-threadstorage/azuredeploy.json
+++ b/scenarios/Agents/setup/standard-agent-with-threadstorage/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "3586167999213672571"
+      "templateHash": "11260517981500011816"
     }
   },
   "parameters": {
@@ -1594,7 +1594,7 @@
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}-deployment', toLower(format('{0}', variables('projectName'))), variables('uniqueSuffix'))]",
+      "name": "[format('cosmos-ra-{0}-{1}-deployment', toLower(format('{0}', variables('projectName'))), variables('uniqueSuffix'))]",
       "subscriptionId": "[variables('cosmosDBSubscriptionId')]",
       "resourceGroup": "[variables('cosmosDBResourceGroupName')]",
       "properties": {

--- a/scenarios/Agents/setup/standard-agent-with-threadstorage/main.bicep
+++ b/scenarios/Agents/setup/standard-agent-with-threadstorage/main.bicep
@@ -242,7 +242,7 @@ module addCapabilityHost 'modules-standard/add-capability-host.bicep' = {
 
 
 module cosmosContainerRoleAssignments 'modules-standard/cosmos-container-role-assignment.bicep' = {
-  name: '${toLower('${projectName}')}-${uniqueSuffix}-deployment'
+  name: 'cosmos-ra-${toLower('${projectName}')}-${uniqueSuffix}-deployment'
   scope: resourceGroup(cosmosDBSubscriptionId, cosmosDBResourceGroupName)
   params: {
     cosmosAccountName: aiDependencies.outputs.cosmosDBName

--- a/scenarios/Agents/setup/standard-agent-with-threadstorage/main.bicep
+++ b/scenarios/Agents/setup/standard-agent-with-threadstorage/main.bicep
@@ -242,7 +242,7 @@ module addCapabilityHost 'modules-standard/add-capability-host.bicep' = {
 
 
 module cosmosContainerRoleAssignments 'modules-standard/cosmos-container-role-assignment.bicep' = {
-  name: 'cosmos-container-role-assignments-${projectName}-${uniqueSuffix}-deployment'
+  name: '${toLower('${projectName}')}-${uniqueSuffix}-deployment'
   scope: resourceGroup(cosmosDBSubscriptionId, cosmosDBResourceGroupName)
   params: {
     cosmosAccountName: aiDependencies.outputs.cosmosDBName

--- a/scenarios/Agents/setup/standard-agent-with-threadstorage/modules-standard/cosmos-container-role-assignment.bicep
+++ b/scenarios/Agents/setup/standard-agent-with-threadstorage/modules-standard/cosmos-container-role-assignment.bicep
@@ -13,6 +13,7 @@ param projectWorkspaceId string
 
 var userThreadName = '${projectWorkspaceId}-thread-message-store'
 var systemThreadName = '${projectWorkspaceId}-system-thread-message-store'
+var agentEntityStoreName = '${projectWorkspaceId}-agent-entity-store'
 
 
 resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2024-12-01-preview' existing = {
@@ -36,6 +37,10 @@ resource containerSystemMessageStore 'Microsoft.DocumentDB/databaseAccounts/sqlD
   name: systemThreadName
 }
 
+resource containerAgentEntityStore 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-12-01-preview' existing = {
+  parent: database
+  name: agentEntityStoreName
+}
 
 var roleDefinitionId = resourceId(
   'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', 
@@ -45,6 +50,7 @@ var roleDefinitionId = resourceId(
 
 var scopeSystemContainer = '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.DocumentDB/databaseAccounts/${cosmosAccountName}/dbs/enterprise_memory/colls/${systemThreadName}'
 var scopeUserContainer = '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.DocumentDB/databaseAccounts/${cosmosAccountName}/dbs/enterprise_memory/colls/${userThreadName}'
+var scopeAgentEntityContainer = '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.DocumentDB/databaseAccounts/${cosmosAccountName}/dbs/enterprise_memory/colls/${agentEntityStoreName}'
 
 resource containerRoleAssignmentUserContainer 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2022-05-15' = {
   parent: cosmosAccount
@@ -63,5 +69,15 @@ resource containerRoleAssignmentSystemContainer 'Microsoft.DocumentDB/databaseAc
     principalId: aiProjectPrincipalId
     roleDefinitionId: roleDefinitionId
     scope: scopeSystemContainer
+  }
+}
+
+resource containerRoleAssignmentAgentEntityContainer 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2022-05-15' = {
+  parent: cosmosAccount
+  name: guid(aiProjectId, containerAgentEntityStore.id, roleDefinitionId)
+  properties: {
+    principalId: aiProjectPrincipalId
+    roleDefinitionId: roleDefinitionId
+    scope: scopeAgentEntityContainer
   }
 }


### PR DESCRIPTION
# Description
As part of agent thread-storage feature, a new container was introduced to manage agent scoped entities. This PR updates the standard agent setup biceps to include the right role assignments for this new container.

This also updates the role-assignment name to make sure we don't exceed the naming convention limit of 66.

# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
