### PR TITLE
chore: Preserve cell name in metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       language: system
       types_or: [jupyter]
       minimum_pre_commit_version: 2.9.2
-      args: ["-m", "tox", "-qqq", "run", "-e", "nb-clean", "--", "clean", "--preserve-cell-metadata", "tags", "--"]
+      args: ["-m", "tox", "-qqq", "run", "-e", "nb-clean", "--", "clean", "--preserve-cell-metadata", "tags", "name", "--"]
     - id: ruff
       name: ruff
       description: "Run 'ruff' for extremely fast Python linting"


### PR DESCRIPTION
# Description

This PR updates our CI to preserve the "name" field in cell metadata, leveraged by our docs.

Related to #264 


# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [ ] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [ ] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
