### PR TITLE
Changes to run as AzureCliCredential from notebook in VSC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ deployment.json
 *result.jsonl
 *results.json
 *results.jsonl
+*.scan_*
+*-Scan.json
 
 ## Python Gitignore
 ## From: https://github.com/github/gitignore/blob/main/Python.gitignore

--- a/scenarios/evaluate/AI_RedTeaming/AI_RedTeaming.ipynb
+++ b/scenarios/evaluate/AI_RedTeaming/AI_RedTeaming.ipynb
@@ -17,7 +17,13 @@
     "### Prerequisite\n",
     "First, if you have an Azure subscription, create an [Azure AI hub](https://learn.microsoft.com/en-us/azure/ai-studio/concepts/ai-resources) then [create an Azure AI project](https://learn.microsoft.com/en-us/azure/ai-studio/concepts/ai-resources). AI projects and Hubs can be served within a private network and are compatible with private endpoints. You **do not** need to provide your own LLM deployment as the AI Red Teaming Agent hosts adversarial models for both simulation and evaluation of harmful content and connects to it via your Azure AI project.\n",
     "\n",
-    "**Note**: In order to upload your results to Azure AI Foundry, you must have the `Storage Blob Data Contributor` role\n",
+    "In order to upload your results to Azure AI Foundry:\n",
+    "- Your AI Foundry project must have a connection (*Connected Resources*) to a storage account with `Microsoft Entra ID` authentication enabled.\n",
+    "- Your AI Foundry project must have the `Storage Blob Data Contributor` role in the storage account.\n",
+    "- You must have the `Storage Blob Data Contributor` role in the storage account.\n",
+    "- You must have network access to the storage account.\n",
+    "\n",
+    "For more information see: https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/run-scans-ai-red-teaming-agent\n",
     "\n",
     "**Important**: First, ensure that you've installed the [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) and then make sure to authenticate to Azure using `az login` in your terminal before running this notebook.\n",
     "\n",
@@ -38,7 +44,7 @@
     "\n",
     "```bash\n",
     "pip install uv\n",
-    "uv pip install azure-ai-evaluation[redteam] azure-identity openai\n",
+    "uv pip install azure-ai-evaluation[redteam] azure-identity openai azure-ai-projects\n",
     "```\n",
     "\n",
     "\n",
@@ -65,14 +71,16 @@
     "import os\n",
     "\n",
     "# Azure imports\n",
-    "from azure.identity import DefaultAzureCredential, get_bearer_token_provider\n",
+    "from azure.identity import AzureCliCredential, get_bearer_token_provider\n",
     "from azure.ai.evaluation.red_team import RedTeam, RiskCategory, AttackStrategy\n",
     "\n",
     "# OpenAI imports\n",
     "from openai import AzureOpenAI\n",
     "\n",
+    "!az login\n",
+    "\n",
     "# Initialize Azure credentials\n",
-    "credential = DefaultAzureCredential()"
+    "credential = AzureCliCredential()"
    ]
   },
   {
@@ -82,6 +90,8 @@
     "### Set Up Your Environment Variables\n",
     "\n",
     "Set the following variables for use in this notebook. These variables connect to your Azure resources and model deployments.\n",
+    "\n",
+    "Set these variables by creating an `.env` file in the root of your python project.\n",
     "\n",
     "**Note:** You can find these values in your Azure AI Foundry project or Azure OpenAI resource."
    ]
@@ -113,18 +123,12 @@
    "outputs": [],
    "source": [
     "# Azure AI Project information\n",
-    "azure_ai_project = {\n",
-    "    \"subscription_id\": os.environ.get(\"AZURE_SUBSCRIPTION_ID\"),\n",
-    "    \"resource_group_name\": os.environ.get(\"AZURE_RESOURCE_GROUP_NAME\"),\n",
-    "    \"project_name\": os.environ.get(\"AZURE_PROJECT_NAME\"),\n",
-    "}\n",
+    "azure_ai_project = os.environ.get(\"AZURE_PROJECT_ENDPOINT\") \n",
     "\n",
     "# Azure OpenAI deployment information\n",
     "azure_openai_deployment = os.environ.get(\"AZURE_OPENAI_DEPLOYMENT\")  # e.g., \"gpt-4\"\n",
-    "azure_openai_endpoint = os.environ.get(\n",
-    "    \"AZURE_OPENAI_ENDPOINT\"\n",
-    ")  # e.g., \"https://endpoint-name.openai.azure.com/openai/deployments/deployment-name/chat/completions\"\n",
-    "azure_openai_api_key = os.environ.get(\"AZURE_OPENAI_API_KEY\")  # e.g., \"your-api-key\"\n",
+    "azure_openai_endpoint = os.environ.get(\"AZURE_OPENAI_ENDPOINT\") # e.g., \"https://endpoint-name.openai.azure.com/openai/deployments/deployment-name/chat/completions\"\n",
+    "azure_openai_api_key = os.environ.get(\"AZURE_OPENAI_API_KEY\") # e.g., \"your-api-key\"\n",
     "azure_openai_api_version = os.environ.get(\"AZURE_OPENAI_API_VERSION\")  # Use the latest API version"
    ]
   },
@@ -280,7 +284,9 @@
    "source": [
     "# Run the red team scan called \"Intermediary-Model-Target-Scan\"\n",
     "result = await red_team.scan(\n",
-    "    target=azure_oai_model_config, scan_name=\"Intermediary-Model-Target-Scan\", attack_strategies=[AttackStrategy.Flip]\n",
+    "    target=azure_oai_model_config, \n",
+    "    scan_name=\"Intermediary-Model-Target-Scan\", \n",
+    "    attack_strategies=[AttackStrategy.Flip],\n",
     ")"
    ]
   },
@@ -307,7 +313,7 @@
     "    context: Optional[Dict[str, Any]] = None,  # noqa: ARG001\n",
     ") -> dict[str, list[dict[str, str]]]:\n",
     "    # Get token provider for Azure AD authentication\n",
-    "    token_provider = get_bearer_token_provider(DefaultAzureCredential(), \"https://cognitiveservices.azure.com/.default\")\n",
+    "    token_provider = get_bearer_token_provider(credential, \"https://cognitiveservices.azure.com/.default\")\n",
     "\n",
     "    # Initialize Azure OpenAI client\n",
     "    client = AzureOpenAI(\n",
@@ -476,7 +482,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "test-3.10",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -489,7 +495,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Description

- Allows the notebook to be run with current RedTeam class
- Allows the notebook to be run from Visual Studio Code and AzureCliCredential instead of Default
- This fixes authentication issues when the notebook can not access local key file for managed credentials.
- Improved text descriptions to set it up manually

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure-Samples/azureai-samples/blob/main/CONTRIBUTING.md)
- [x] I have coordinated with the docs team (mldocs@microsoft.com) if this PR deletes files or changes any file names or file extensions.
- [x] This notebook or file is added to the [CODEOWNERS](https://github.com/Azure-Samples/azureai-samples/blob/main/.github/CODEOWNERS) file, pointing to the author or the author's team.
